### PR TITLE
fix: Add missing constructor overloads and `Blob` re-export

### DIFF
--- a/.changeset/pink-papayas-doubt.md
+++ b/.changeset/pink-papayas-doubt.md
@@ -1,0 +1,5 @@
+---
+'fetch-nodeshim': patch
+---
+
+Add missing constructor type overloads and add missing `Blob` re-export

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,11 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: TypeScript
-        run: pnpm run check
-
       - name: Unit Tests
         run: pnpm run test
+
+      - name: Type checks
+        run: pnpm run check:all
 
       - name: Build
         run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest test",
     "test:run": "vitest test --run",
     "build": "rollup -c ./scripts/rollup.config.mjs",
+    "postbuild": "tsc --noEmit ./dist/minifetch.d.ts",
     "check": "tsc --noEmit",
     "check:node18": "tsc --noEmit -p ./tsconfig-node18.json",
     "check:node20": "tsc --noEmit -p ./tsconfig-node20.json",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "test": "vitest test",
     "test:run": "vitest test --run",
     "check": "tsc --noEmit",
-    "build": "rollup -c ./scripts/rollup.config.mjs",
+    "check:node18": "tsc --noEmit -p ./tsconfig-node18.json",
+    "check:node20": "tsc --noEmit -p ./tsconfig-node20.json",
+    "check:all": "run-s check check:node18 check:node20",
     "clean": "rimraf dist node_modules/.cache",
-    "prepublishOnly": "run-s clean build check test:run",
+    "prepublishOnly": "run-s clean build check:all test:run",
     "prepare": "node ./scripts/prepare.js || true",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
     "changeset:publish": "changeset publish"
@@ -52,6 +54,8 @@
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",
+    "@types-internal/node-18": "npm:@types/node@^18.19.0",
+    "@types-internal/node-20": "npm:@types/node@^20.17.0",
     "@types/node": "^22.12.0",
     "busboy": "^0.3.1",
     "dotenv": "^16.4.7",
@@ -64,7 +68,6 @@
     "rollup-plugin-cjs-check": "^1.0.3",
     "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.7.3",
-    "undici-types": "^6.20.0",
     "vitest": "^3.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "vitest test",
     "test:run": "vitest test --run",
+    "build": "rollup -c ./scripts/rollup.config.mjs",
     "check": "tsc --noEmit",
     "check:node18": "tsc --noEmit -p ./tsconfig-node18.json",
     "check:node20": "tsc --noEmit -p ./tsconfig-node20.json",
@@ -68,6 +69,7 @@
     "rollup-plugin-cjs-check": "^1.0.3",
     "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.7.3",
+    "undici-types": "^6.20.0",
     "vitest": "^3.0.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,12 @@ importers:
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.32.1)
+      '@types-internal/node-18':
+        specifier: npm:@types/node@^18.19.0
+        version: '@types/node@18.19.74'
+      '@types-internal/node-20':
+        specifier: npm:@types/node@^20.17.0
+        version: '@types/node@20.17.16'
       '@types/node':
         specifier: ^22.12.0
         version: 22.12.0
@@ -68,9 +74,6 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
-      undici-types:
-        specifier: ^6.20.0
-        version: 6.20.0
       vitest:
         specifier: ^3.0.4
         version: 3.0.4(@types/node@22.12.0)(terser@5.37.0)(yaml@2.7.0)
@@ -598,6 +601,12 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@18.19.74':
+    resolution: {integrity: sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==}
+
+  '@types/node@20.17.16':
+    resolution: {integrity: sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==}
 
   '@types/node@22.12.0':
     resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
@@ -1908,6 +1917,12 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
@@ -2620,6 +2635,14 @@ snapshots:
   '@types/estree@1.0.6': {}
 
   '@types/node@12.20.55': {}
+
+  '@types/node@18.19.74':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/node@20.17.16':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/node@22.12.0':
     dependencies:
@@ -4026,6 +4049,10 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@5.26.5: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+      undici-types:
+        specifier: ^6.20.0
+        version: 6.20.0
       vitest:
         specifier: ^3.0.4
         version: 3.0.4(@types/node@22.12.0)(terser@5.37.0)(yaml@2.7.0)

--- a/src/body.ts
+++ b/src/body.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'node:stream';
 import { isAnyArrayBuffer } from 'node:util/types';
 import { randomBytes } from 'node:crypto';
+import { Blob, FormData, URLSearchParams } from './webstd';
 
 export type BodyInit =
   | Exclude<RequestInit['body'], undefined | null>

--- a/src/webstd.ts
+++ b/src/webstd.ts
@@ -45,7 +45,7 @@ interface _File extends _Blob, Or<File, globalThis.File> {
 }
 interface _File extends Or<globalThis.File, buffer.File> {}
 interface FileClass extends Or<typeof globalThis.File, typeof buffer.File> {}
-const _File: FileClass = File || buffer.File;
+const _File: FileClass = globalThis.File || buffer.File;
 if (typeof globalThis.File === 'undefined') {
   globalThis.File = _File;
 }

--- a/src/webstd.ts
+++ b/src/webstd.ts
@@ -1,5 +1,3 @@
-/// <reference types="@types/node" />
-
 import * as buffer from 'node:buffer';
 
 type Or<T, U> = void extends T ? U : T;
@@ -41,14 +39,19 @@ export type BodyInit =
 
 // See: https://nodejs.org/docs/latest-v20.x/api/globals.html#class-file
 // The `File` global was only added in Node.js 20
-interface _File extends _Blob, Or<File, globalThis.File> {}
-const _File: Or<typeof File, typeof buffer.File> = buffer.File;
+interface _File extends _Blob, Or<File, globalThis.File> {
+  readonly name: string;
+  readonly lastModified: number;
+}
+interface _File extends Or<globalThis.File, buffer.File> {}
+interface FileClass extends Or<typeof globalThis.File, typeof buffer.File> {}
+const _File: FileClass = File || buffer.File;
 if (typeof globalThis.File === 'undefined') {
   globalThis.File = _File;
 }
 
 declare global {
-  var File: typeof _File;
+  var File: _File;
 }
 
 // There be dragons here.

--- a/src/webstd.ts
+++ b/src/webstd.ts
@@ -50,10 +50,6 @@ if (typeof globalThis.File === 'undefined') {
   globalThis.File = _File;
 }
 
-declare global {
-  var File: _File;
-}
-
 // There be dragons here.
 // This is complex because of overlapping definitions in lib.dom, @types/node, and undici-types
 // Some types define and overload constructor interfaces with type interfaces

--- a/tsconfig-node18.json
+++ b/tsconfig-node18.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@types-internal/node-18"],
+    "paths": {
+      "@types/node": ["node_modules/@types-internal/node-18"],
+      "@types/node/*": ["node_modules/@types-internal/node-18/*"]
+    }
+  },
+  "include": ["src", "packages"]
+}

--- a/tsconfig-node20.json
+++ b/tsconfig-node20.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@types-internal/node-20"],
+    "paths": {
+      "@types/node": ["node_modules/@types-internal/node-20"],
+      "@types/node/*": ["node_modules/@types-internal/node-20/*"]
+    }
+  },
+  "include": ["src", "packages"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["@types/node"],
     "baseUrl": "./",
     "rootDir": ".",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
- Add missing constructor types
- Define `Blob` re-export
- Run type checks against `@types/node` of multiple majors
- Remove global `File` declaration
- Fix `File` constructor and base type