### PR TITLE
fix: Premature callback in `InflateStream` before flush

### DIFF
--- a/.changeset/tender-planes-brush.md
+++ b/.changeset/tender-planes-brush.md
@@ -1,0 +1,5 @@
+---
+'fetch-nodeshim': patch
+---
+
+Fix `_final` on `InflateStream` calling `callback` before full flush.

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -37,10 +37,12 @@ class InflateStream extends Transform {
 
   _final(callback: TransformCallback) {
     if (this._inflate) {
+      this._inflate.once('finish', callback);
       this._inflate.end();
       this._inflate = undefined;
+    } else {
+      callback();
     }
-    callback();
   }
 }
 


### PR DESCRIPTION
Technically, `_final` shouldn't be called unless it's fully flushed, but we don't have to rely on this