### PR TITLE
fix: Reset `agent` on retry/redirect

### DIFF
--- a/.changeset/slimy-boats-worry.md
+++ b/.changeset/slimy-boats-worry.md
@@ -1,0 +1,5 @@
+---
+'fetch-nodeshim': patch
+---
+
+Reset `requestOptions.agent` on retry/redirect

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -134,15 +134,14 @@ async function _fetch(
     signal,
   } satisfies http.RequestOptions;
 
-  requestOptions.agent =
-    requestOptions.protocol === 'https:'
-      ? getHttpsAgent(requestOptions)
-      : getHttpAgent(requestOptions);
-
   function _call(
     resolve: (response: Response | Promise<Response>) => void,
     reject: (reason?: any) => void
   ) {
+    requestOptions.agent =
+      requestOptions.protocol === 'https:'
+        ? getHttpsAgent(requestOptions)
+        : getHttpAgent(requestOptions);
     const method = requestOptions.method;
     const protocol = requestOptions.protocol === 'https:' ? https : http;
     const outgoing = protocol.request(requestOptions);


### PR DESCRIPTION
We call back into the `_call` closure recursively if a redirect is being followed. However, this must also reset the `agent`, since it may have changed.