### PR TITLE
fix: Add `connectTimeout` and set default to 30s for HTML requests

### DIFF
--- a/.changeset/polite-loops-cross.md
+++ b/.changeset/polite-loops-cross.md
@@ -1,0 +1,5 @@
+---
+'fetch-nodeshim': patch
+---
+
+Add configurable `connectTimeout` to override connection timeout. The default will now also be 30s if the request contains `text/html` in the `Accept` header

--- a/src/__tests__/fetch.test.ts
+++ b/src/__tests__/fetch.test.ts
@@ -67,6 +67,12 @@ describe(fetch, () => {
     await expect(() => fetch('http://localhost:50000/')).rejects.toThrow();
   }, 1_000);
 
+  it('should reject with error when connectTimeout is exceeded', async () => {
+    await expect(() =>
+      fetch('http://10.255.255.1/', { connectTimeout: 100 })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Request timed out]`);
+  }, 5_000);
+
   it('should resolve into response', async () => {
     const response = await fetch(new URL('hello', baseURL));
     expect(response.url).toBe(`${baseURL}hello`);

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -163,9 +163,15 @@ async function _fetch(
   const requestHeaders = new Headers(
     init?.headers ?? (initFromRequest ? input.headers : undefined)
   );
+
+  let DEFAULT_TIMEOUT = 5_000;
+  if (requestHeaders.get('accept')?.includes('text/html')) {
+    DEFAULT_TIMEOUT = 30_000;
+  }
+
   const requestOptions = {
     ...urlToHttpOptions(requestUrl),
-    timeout: 5_000,
+    timeout: init?.connectTimeout ?? DEFAULT_TIMEOUT,
     method: methodToHttpOption(initFromRequest ? input.method : init?.method),
     signal,
   } satisfies http.RequestOptions;

--- a/src/webstd.ts
+++ b/src/webstd.ts
@@ -1,11 +1,5 @@
 import * as buffer from 'node:buffer';
 
-declare global {
-  interface RequestInit {
-    connectTimeout?: number;
-  }
-}
-
 type Or<T, U> = void extends T ? U : T;
 
 export type HeadersInit =

--- a/src/webstd.ts
+++ b/src/webstd.ts
@@ -1,5 +1,11 @@
 import * as buffer from 'node:buffer';
 
+declare global {
+  interface RequestInit {
+    connectTimeout?: number;
+  }
+}
+
 type Or<T, U> = void extends T ? U : T;
 
 export type HeadersInit =
@@ -56,6 +62,7 @@ if (typeof globalThis.File === 'undefined') {
 // Here, we have to account for global differences and split the overloads apart
 
 interface _RequestInit extends Or<RequestInit, globalThis.RequestInit> {
+  connectTimeout?: number;
   duplex?: 'half';
 }
 interface _ResponseInit extends Or<ResponseInit, globalThis.ResponseInit> {}


### PR DESCRIPTION
## Summary

Make the connect timeout configurable via a custom `connectTimeout` parameter and default to 30s for HTML requests.

## Set of changes

- Add 30s default for HTML requests
- Add custom `connectTimeout` to `RequestInit`