### PR TITLE
patch: Preserve casing of headers when passed as non-Headers object

### DIFF
--- a/.changeset/breezy-hounds-battle.md
+++ b/.changeset/breezy-hounds-battle.md
@@ -1,0 +1,5 @@
+---
+'fetch-nodeshim': patch
+---
+
+Preserve casing of headers when they're passed as non-Headers input, i.e. as tuple list or dictionary

--- a/src/__tests__/fetch-proxied.test.ts
+++ b/src/__tests__/fetch-proxied.test.ts
@@ -59,6 +59,9 @@ describe('fetch via HTTP proxy', () => {
       headers: expect.objectContaining({
         connection: 'keep-alive',
       }),
+      rawHeaders: expect.objectContaining({
+        Connection: 'keep-alive',
+      }),
       inspect: true,
       method: 'GET',
       url: '/inspect',

--- a/src/__tests__/fetch.test.ts
+++ b/src/__tests__/fetch.test.ts
@@ -201,6 +201,50 @@ describe(fetch, () => {
         headers: expect.objectContaining({ host: 'example.com' }),
       });
     });
+
+    it('should preserve header casing when headers are passed as a plain object', async () => {
+      const response = await fetch(new URL('inspect', baseURL), {
+        headers: {
+          'X-Custom-Header': 'abc',
+          Authorization: 'Bearer token',
+          'content-type': 'text/plain',
+        },
+      });
+      const { rawHeaders } = await response.json();
+      expect(rawHeaders).toMatchObject({
+        'X-Custom-Header': 'abc',
+        Authorization: 'Bearer token',
+        'content-type': 'text/plain',
+      });
+    });
+
+    it('should preserve header casing when headers are passed as an array of tuples', async () => {
+      const response = await fetch(new URL('inspect', baseURL), {
+        headers: [
+          ['X-Custom-Header', 'abc'],
+          ['Authorization', 'Bearer token'],
+        ],
+      });
+      const { rawHeaders } = await response.json();
+      expect(rawHeaders).toMatchObject({
+        'X-Custom-Header': 'abc',
+        Authorization: 'Bearer token',
+      });
+    });
+
+    it('should lowercase header names when headers are passed as a Headers instance', async () => {
+      const response = await fetch(new URL('inspect', baseURL), {
+        headers: new Headers({
+          'X-Custom-Header': 'abc',
+          Authorization: 'Bearer token',
+        }),
+      });
+      const { rawHeaders } = await response.json();
+      expect(rawHeaders).toMatchObject({
+        'x-custom-header': 'abc',
+        authorization: 'Bearer token',
+      });
+    });
   });
 
   describe('redirects', () => {

--- a/src/__tests__/fetch.test.ts
+++ b/src/__tests__/fetch.test.ts
@@ -232,6 +232,17 @@ describe(fetch, () => {
       });
     });
 
+    it('should merge tuple headers with the same name into a combined value', async () => {
+      const response = await fetch(new URL('inspect', baseURL), {
+        headers: [
+          ['X-Custom-Header', 'abc'],
+          ['X-Custom-Header', 'def'],
+        ],
+      });
+      const { headers } = await response.json();
+      expect(headers['x-custom-header']).toBe('abc, def');
+    });
+
     it('should lowercase header names when headers are passed as a Headers instance', async () => {
       const response = await fetch(new URL('inspect', baseURL), {
         headers: new Headers({

--- a/src/__tests__/fetch.test.ts
+++ b/src/__tests__/fetch.test.ts
@@ -210,7 +210,7 @@ describe(fetch, () => {
           'content-type': 'text/plain',
         },
       });
-      const { rawHeaders } = await response.json();
+      const { rawHeaders } = (await response.json()) as any;
       expect(rawHeaders).toMatchObject({
         'X-Custom-Header': 'abc',
         Authorization: 'Bearer token',
@@ -225,7 +225,7 @@ describe(fetch, () => {
           ['Authorization', 'Bearer token'],
         ],
       });
-      const { rawHeaders } = await response.json();
+      const { rawHeaders } = (await response.json()) as any;
       expect(rawHeaders).toMatchObject({
         'X-Custom-Header': 'abc',
         Authorization: 'Bearer token',
@@ -239,7 +239,7 @@ describe(fetch, () => {
           ['X-Custom-Header', 'def'],
         ],
       });
-      const { headers } = await response.json();
+      const { headers } = (await response.json()) as any;
       expect(headers['x-custom-header']).toBe('abc, def');
     });
 
@@ -250,7 +250,7 @@ describe(fetch, () => {
           Authorization: 'Bearer token',
         }),
       });
-      const { rawHeaders } = await response.json();
+      const { rawHeaders } = (await response.json()) as any;
       expect(rawHeaders).toMatchObject({
         'x-custom-header': 'abc',
         authorization: 'Bearer token',

--- a/src/__tests__/fetch.test.ts
+++ b/src/__tests__/fetch.test.ts
@@ -306,6 +306,28 @@ describe(fetch, () => {
       }
     );
 
+    it.each([[301], [302], [303]])(
+      'should remove body, Content-Length, and Content-Type headers on %d redirect that changes method to GET',
+      async code => {
+        const response = await fetch(new URL(`redirect/${code}`, baseURL), {
+          method: 'POST',
+          body: 'a=1',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Content-Length': '3',
+          },
+        });
+        expect(response.url).toBe(`${baseURL}inspect`);
+        const inspect: any = await response.json();
+        expect(inspect).toMatchObject({
+          method: 'GET',
+          body: '',
+        });
+        expect(inspect.headers).not.toHaveProperty('content-type');
+        expect(inspect.headers).not.toHaveProperty('content-length');
+      }
+    );
+
     it('should not follow non-GET redirect if body is a readable stream', async () => {
       await expect(() =>
         fetch(new URL('redirect/307', baseURL), {

--- a/src/__tests__/fetch.test.ts
+++ b/src/__tests__/fetch.test.ts
@@ -243,6 +243,17 @@ describe(fetch, () => {
       expect(headers['x-custom-header']).toBe('abc, def');
     });
 
+    it('should merge tuple headers with the same name but different casing into a combined value', async () => {
+      const response = await fetch(new URL('inspect', baseURL), {
+        headers: [
+          ['X-Custom-Header', 'abc'],
+          ['X-custom-header', 'def'],
+        ],
+      });
+      const { headers } = (await response.json()) as any;
+      expect(headers['x-custom-header']).toBe('abc, def');
+    });
+
     it('should lowercase header names when headers are passed as a Headers instance', async () => {
       const response = await fetch(new URL('inspect', baseURL), {
         headers: new Headers({

--- a/src/__tests__/utils/server.js
+++ b/src/__tests__/utils/server.js
@@ -442,12 +442,18 @@ export default class TestServer {
         body += c;
       });
       request.on('end', () => {
+        // Convert rawHeaders array to an object preserving original casing
+        const rawHeadersObj = {};
+        for (let i = 0; i < request.rawHeaders.length; i += 2) {
+          rawHeadersObj[request.rawHeaders[i]] = request.rawHeaders[i + 1];
+        }
         res.end(
           JSON.stringify({
             inspect: true,
             method: request.method,
             url: request.url,
             headers: request.headers,
+            rawHeaders: rawHeadersObj,
             body,
           })
         );

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -55,7 +55,11 @@ const assignOutgoingMessageHeaders = (
     collection = headers;
   } else {
     collection = {};
-    for (const [key, value] of headers) {
+    const canonicalNames = new Map();
+    for (const [name, value] of headers) {
+      const lowerKey = name.toLowerCase();
+      let key = canonicalNames.get(lowerKey) ?? name;
+      if (!canonicalNames.has(lowerKey)) canonicalNames.set(lowerKey, name);
       if (Array.isArray(collection[key])) {
         collection[key].push(value);
       } else if (collection[key] != undefined) {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -6,11 +6,20 @@ import * as url from 'node:url';
 
 import { extractBody } from './body';
 import { createContentDecoder } from './encoding';
-import { URL, Request, RequestInit, Response } from './webstd';
+import {
+  URL,
+  Request,
+  RequestInit,
+  Response,
+  HeadersInit,
+  Headers,
+} from './webstd';
 import { getHttpsAgent, getHttpAgent } from './agent';
 
 /** Maximum allowed redirects (matching Chromium's limit) */
 const MAX_REDIRECTS = 20;
+
+const DEFAULT_TIMEOUT = 30_000;
 
 const parseURL = (input: string, base?: string | URL): URL | null => {
   try {
@@ -19,6 +28,12 @@ const parseURL = (input: string, base?: string | URL): URL | null => {
     return null;
   }
 };
+
+const isHeaders = (x: unknown): x is Headers =>
+  x != null &&
+  typeof x === 'object' &&
+  'append' in x &&
+  typeof x.append === 'function';
 
 /** Convert Node.js raw headers array to Headers */
 const headersOfRawHeaders = (rawHeaders: readonly string[]): Headers => {
@@ -31,18 +46,23 @@ const headersOfRawHeaders = (rawHeaders: readonly string[]): Headers => {
 /** Assign Headers to a Node.js OutgoingMessage (request) */
 const assignOutgoingMessageHeaders = (
   outgoing: http.OutgoingMessage,
-  headers: Headers
+  headers: HeadersInit
 ) => {
   // Preassemble array headers, mostly only for Set-Cookie
   // We're avoiding `getSetCookie` since support is unclear in Node 18
-  const collection: Record<string, string | string[]> = {};
-  for (const [key, value] of headers) {
-    if (Array.isArray(collection[key])) {
-      collection[key].push(value);
-    } else if (collection[key] != undefined) {
-      collection[key] = [collection[key], value];
-    } else {
-      collection[key] = value;
+  let collection: Record<string, string | readonly string[]>;
+  if (!Array.isArray(headers) && !isHeaders(headers)) {
+    collection = headers;
+  } else {
+    collection = {};
+    for (const [key, value] of headers) {
+      if (Array.isArray(collection[key])) {
+        collection[key].push(value);
+      } else if (collection[key] != undefined) {
+        collection[key] = [collection[key] as string, value];
+      } else {
+        collection[key] = value;
+      }
     }
   }
   // We don't use `setHeaders` due to a Bun bug (Fix: https://github.com/oven-sh/bun/pull/27050)
@@ -160,14 +180,8 @@ async function _fetch(
   let requestBody = extractBody(initBody);
   let redirects = 0;
 
-  const requestHeaders = new Headers(
-    init?.headers ?? (initFromRequest ? input.headers : undefined)
-  );
-
-  let DEFAULT_TIMEOUT = 5_000;
-  if (requestHeaders.get('accept')?.includes('text/html')) {
-    DEFAULT_TIMEOUT = 30_000;
-  }
+  const requestHeaders =
+    init?.headers ?? (initFromRequest ? input.headers : undefined);
 
   const requestOptions = {
     ...urlToHttpOptions(requestUrl),
@@ -263,7 +277,6 @@ async function _fetch(
           ) {
             requestBody = extractBody(null);
             requestOptions.method = 'GET';
-            requestHeaders.delete('Content-Length');
           } else if (
             requestBody.body != null &&
             requestBody.contentLength == null
@@ -315,23 +328,25 @@ async function _fetch(
 
     outgoing.on('error', destroy);
 
-    if (!requestHeaders.has('Accept')) {
-      requestHeaders.set('Accept', '*/*');
+    if (requestHeaders) {
+      assignOutgoingMessageHeaders(outgoing, requestHeaders);
     }
-    if (!requestHeaders.has('Content-Type') && requestBody.contentType) {
-      requestHeaders.set('Content-Type', requestBody.contentType);
+
+    if (!outgoing.hasHeader('Accept')) {
+      outgoing.setHeader('Accept', '*/*');
+    }
+    if (!outgoing.hasHeader('Content-Type') && requestBody.contentType) {
+      outgoing.setHeader('Content-Type', requestBody.contentType);
     }
 
     if (
       requestBody.body == null &&
       (method === 'POST' || method === 'PUT' || method === 'PATCH')
     ) {
-      requestHeaders.set('Content-Length', '0');
+      outgoing.setHeader('Content-Length', '0');
     } else if (requestBody.body != null && requestBody.contentLength != null) {
-      requestHeaders.set('Content-Length', `${requestBody.contentLength}`);
+      outgoing.setHeader('Content-Length', `${requestBody.contentLength}`);
     }
-
-    assignOutgoingMessageHeaders(outgoing, requestHeaders);
 
     if (requestBody.body == null) {
       outgoing.end();

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -32,8 +32,7 @@ const parseURL = (input: string, base?: string | URL): URL | null => {
 const isHeaders = (x: unknown): x is Headers =>
   x != null &&
   typeof x === 'object' &&
-  'append' in x &&
-  typeof x.append === 'function';
+  (('append' in x && typeof x.append === 'function') || x instanceof Headers);
 
 /** Convert Node.js raw headers array to Headers */
 const headersOfRawHeaders = (rawHeaders: readonly string[]): Headers => {
@@ -43,18 +42,20 @@ const headersOfRawHeaders = (rawHeaders: readonly string[]): Headers => {
   return headers;
 };
 
+type HeadersDict = Record<string, string | readonly string[]>;
+
 /** Assign Headers to a Node.js OutgoingMessage (request) */
 const assignOutgoingMessageHeaders = (
   outgoing: http.OutgoingMessage,
   headers: HeadersInit
-) => {
+): HeadersDict => {
   // Preassemble array headers, mostly only for Set-Cookie
   // We're avoiding `getSetCookie` since support is unclear in Node 18
-  let collection: Record<string, string | readonly string[]>;
+  let collection: HeadersDict;
   if (!Array.isArray(headers) && !isHeaders(headers)) {
     collection = headers;
   } else {
-    collection = {};
+    collection = Object.create(null);
     const canonicalNames = new Map();
     for (const [name, value] of headers) {
       const lowerKey = name.toLowerCase();
@@ -72,6 +73,19 @@ const assignOutgoingMessageHeaders = (
   // We don't use `setHeaders` due to a Bun bug (Fix: https://github.com/oven-sh/bun/pull/27050)
   for (const key in collection) {
     outgoing.setHeader(key, collection[key]);
+  }
+  return collection;
+};
+
+const stripRedirectHeaders = (headers: HeadersDict | undefined) => {
+  if (headers) {
+    for (const key in headers) {
+      switch (key.toLowerCase()) {
+        case 'content-length':
+        case 'content-type':
+          delete headers[key];
+      }
+    }
   }
 };
 
@@ -184,7 +198,7 @@ async function _fetch(
   let requestBody = extractBody(initBody);
   let redirects = 0;
 
-  const requestHeaders =
+  let requestHeaders =
     init?.headers ?? (initFromRequest ? input.headers : undefined);
 
   const requestOptions = {
@@ -281,6 +295,7 @@ async function _fetch(
           ) {
             requestBody = extractBody(null);
             requestOptions.method = 'GET';
+            stripRedirectHeaders(requestHeaders as HeadersDict);
           } else if (
             requestBody.body != null &&
             requestBody.contentLength == null
@@ -333,7 +348,7 @@ async function _fetch(
     outgoing.on('error', destroy);
 
     if (requestHeaders) {
-      assignOutgoingMessageHeaders(outgoing, requestHeaders);
+      requestHeaders = assignOutgoingMessageHeaders(outgoing, requestHeaders);
     }
 
     if (!outgoing.hasHeader('Accept')) {


### PR DESCRIPTION
## Summary

While this slightly diverges from the Web Fetch API specification (in regards to `Headers` normalising inputs to lower-case and only storing headers in lower-case naming), this is a compromise that preserves the casing explicitly, which is sometimes necessary.

While this is only necessary for APIs that violate the specification, it's unexpected for casing to change when the input isn't passed to the `Headers` class

## Set of changes

- Bypass `new Headers` normalization for request headers
- Remove logic that relies on `requestHeaders`